### PR TITLE
Add mod file id to TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ declare class ModFile {
 	 * @description A File Object representing a file of a specific mod
 	 * @param {Object} file_object - File object to create object from
 	 * @property {string[]} minecraft_versions - The minecraft versions this mod file is compatible with.
+   * @property {number} id - The id of the file object
 	 * @property {string} file_name - The name of the mod file it got stored with.
 	 * @property {string} file_size - The size of the mod file as string. (Yeah it's gross)
 	 * @property {string} release_type - the type of the mod file release.
@@ -16,6 +17,7 @@ declare class ModFile {
 	 * @property {boolean} available - true if the file is available.
 	 */
   minecraft_versions: string[];
+  id: number;
   file_name: string;
   file_size: string;
   release_type: string;


### PR DESCRIPTION
First things first sorry for the fragmented PRs (I'm finding these issues while I work with the API, and I see some things missing)

This pull request adds back the support mod file ids (this is especially useful when you're trying to build URLs or store unique references to project files)

I've noticed, proper documentation is also missing from the JSDocs on the website
![image](https://user-images.githubusercontent.com/24458276/105538178-505ccf00-5cf3-11eb-92de-1786cefc0d10.png)
The first time I've used it was in Javascript and I probably just went guessing from the source code
https://github.com/Mondanzo/mc-curseforge-api/blob/master/objects/Files.js#L155

Anyways, feel free to tweak my implementation and/or add javascript documentation before publishing a new release with the feature